### PR TITLE
Dont limit user to a forced version of certain build tools

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
 requirements:
   build:
     - cmake {{ cmake }} 
-    - make {{ make }}
+    - make
     - {{ compiler('cxx') }}
     - pkg-config {{ pkg_config }}
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   git_rev: v{{ version }}
 
 build:
-  number: 1
+  number: 2
   string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
 
 requirements:


### PR DESCRIPTION
User shouldnt be forced to have specific version of some general tools (e.g. make), if we are not truly using version-specific features. We arent requiring this consistently across many feedstocks.