### PR TITLE
add selector for libgcc pins to fix 1.3 builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,11 +23,17 @@ requirements:
     - {{ compiler('cxx') }}
     - pkg-config {{ pkg_config }}
     - patch
+    # Use pins to control cos6/cos7 match
+    - libgcc-ng  {{ libgcc }}         # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}   # [x86_64 and c_compiler_version == "7.2.*"]
   host:
     - python {{ python }}
     - setuptools {{ setuptools }}
     - protobuf {{ protobuf }}
     - patchelf
+    # Use pins to control cos6/cos7 match
+    - libgcc-ng  {{ libgcc }}         # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}   # [x86_64 and c_compiler_version == "7.2.*"]
   run:
     - python {{ python }} 
     - protobuf {{ protobuf }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0300-fix-incompatible-protobuf-headers-error.patch
 
 build:
-  number: 6
+  number: 7
   string: h{{ PKG_HASH }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
 
 requirements:
@@ -23,17 +23,11 @@ requirements:
     - {{ compiler('cxx') }}
     - pkg-config {{ pkg_config }}
     - patch
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
   host:
     - python {{ python }}
     - setuptools {{ setuptools }}
     - protobuf {{ protobuf }}
     - patchelf
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
   run:
     - python {{ python }} 
     - protobuf {{ protobuf }}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Requires - open-ce/open-ce#501
Remove compiler pins as these are no longer required now, since we are moving to GCC 7.5 on x86.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
