### PR TITLE
fix build on s390x

### DIFF
--- a/recipe/0001-fix-build-failure-on-s390x.patch
+++ b/recipe/0001-fix-build-failure-on-s390x.patch
@@ -1,0 +1,65 @@
+From 154952c77b0fc98d77bdbdbb8dae4a16198e7465 Mon Sep 17 00:00:00 2001
+From: Deepali Chourasia <deepch23@in.ibm.com>
+Date: Wed, 24 May 2023 09:16:35 +0100
+Subject: [PATCH] fix build failure on s390x
+
+---
+ src/normalizer.cc | 10 ++++++----
+ src/normalizer.h  |  1 +
+ 2 files changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/src/normalizer.cc b/src/normalizer.cc
+index 2ab8084..c298055 100644
+--- a/src/normalizer.cc
++++ b/src/normalizer.cc
+@@ -264,10 +264,12 @@ std::string Normalizer::EncodePrecompiledCharsMap(
+ 
+ #ifdef IS_BIG_ENDIAN
+   uint32 *data = reinterpret_cast<uint32 *>(const_cast<char *>(blob.data()));
+-  for (int i = 0; i <= trie_blob.size() / 4; ++i)
++  for (int i = 0; i <= blob.size() / 4; ++i)
+     data[i] = util::Swap32(data[i]);
+ #endif
+ 
++  blob.append(normalized.data(), normalized.size());
++
+   return blob;
+ }
+ 
+@@ -279,8 +281,7 @@ util::Status Normalizer::DecodePrecompiledCharsMap(
+   if (blob.size() <= sizeof(trie_blob_size) ||
+       !string_util::DecodePOD<uint32>(
+           absl::string_view(blob.data(), sizeof(trie_blob_size)),
+-          &trie_blob_size) ||
+-      trie_blob_size >= blob.size()) {
++          &trie_blob_size)) {
+     return util::InternalError("Blob for normalization rule is broken.");
+   }
+ 
+@@ -294,9 +295,10 @@ util::Status Normalizer::DecodePrecompiledCharsMap(
+   blob.remove_prefix(sizeof(trie_blob_size));
+ 
+ #ifdef IS_BIG_ENDIAN
++  CHECK_OR_RETURN(buffer);
+   buffer->assign(blob.data(), trie_blob_size);
+   uint32 *data = reinterpret_cast<uint32 *>(const_cast<char *>(buffer->data()));
+-  for (int i = 0; i < trie_blob_size / 4; ++i) data[i] = util::Swap32(data[i]);
++  for (int i = 0; i < buffer->size() / 4; ++i) data[i] = util::Swap32(data[i]);
+   *trie_blob = absl::string_view(buffer->data(), trie_blob_size);
+ #else
+   *trie_blob = absl::string_view(blob.data(), trie_blob_size);
+diff --git a/src/normalizer.h b/src/normalizer.h
+index c79813c..37fdb8a 100644
+--- a/src/normalizer.h
++++ b/src/normalizer.h
+@@ -22,6 +22,7 @@
+ #include <vector>
+ 
+ #include "common.h"
++#include "util.h"
+ #include "sentencepiece_model.pb.h"
+ #include "sentencepiece_processor.h"
+ #include "third_party/absl/strings/string_view.h"
+-- 
+2.31.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   git_url: https://github.com/google/sentencepiece
   git_rev: v{{ version }}
+  patches:                                      #[s390x]
+    - 0001-fix-build-failure-on-s390x.patch     #[s390x]
 
 build:
-  number: 1
+  number: 2
   string: h{{ PKG_HASH }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   script_env:
     - GCC_11_HOME                        #[ppc_arch == 'p10']


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Added patch for s390x to:
   - Include util.h in normalizer.h to fix the following error:
               ` 'precompiled_charsmap_buffer_' was not declared in this scope`
   - Fix normalizer.cc

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
